### PR TITLE
prevent source maps generation

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "ROLLBAR_ACCESS_TOKEN=${{ secrets.ROLLBAR_ACCESS_TOKEN }}" > .env
       - name: Build and run tests
-        run: docker-compose -p beapengine-staging -f docker-compose-staging.yml up --build -d
+        run: docker compose -p beapengine-staging -f docker-compose-staging.yml up --build -d
       - name: Install dependencies
         run: |
           cd frontend 
@@ -37,7 +37,7 @@ jobs:
           yarn playwright test
       - name: Clean up containers
         if: always()
-        run: docker-compose -p beapengine-staging -f docker-compose-staging.yml down
+        run: docker compose -p beapengine-staging -f docker-compose-staging.yml down
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/playwright_smoke.yml
+++ b/.github/workflows/playwright_smoke.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           echo "ROLLBAR_ACCESS_TOKEN=${{ secrets.ROLLBAR_ACCESS_TOKEN }}" > .env
       - name: Build and run tests
-        run: docker-compose -p beapengine-staging -f docker-compose-staging.yml up --build -d
+        run: docker compose -p beapengine-staging -f docker-compose-staging.yml up --build -d
       - name: Install dependencies
         run: |
           cd frontend 
@@ -35,7 +35,7 @@ jobs:
           yarn playwright test -g @smoke
       - name: Clean up containers
         if: always()
-        run: docker-compose -p beapengine-staging -f docker-compose-staging.yml down
+        run: docker compose -p beapengine-staging -f docker-compose-staging.yml down
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "prepare": "cd .. && husky install",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "build:staging": "env-cmd -f .env.staging yarn build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,6 +110,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@playwright/test": "^1.41.1",
     "@types/history": "^5.0.0",
     "@types/invariant": "^2.2.37",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -87,7 +87,7 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.22.5":
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
   integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
@@ -116,6 +116,21 @@
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz#db58bf57137b623b916e24874ab7188d93d7f68f"
   integrity sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-member-expression-to-functions" "^7.23.0"
+    "@babel/helper-optimise-call-expression" "^7.22.5"
+    "@babel/helper-replace-supers" "^7.24.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.21.0":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz#c806f73788a6800a5cfbbc04d2df7ee4d927cce3"
+  integrity sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-environment-visitor" "^7.22.20"
@@ -369,6 +384,16 @@
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"


### PR DESCRIPTION
This will help production and staging builds, build faster. Also should help us with memory problems during rebuilding. It will also hide our source code from the average joe.