### PR TITLE
Fixed digitalocean_deploy runs-on to ubuntu-22.04 instead of beapengine

### DIFF
--- a/.github/workflows/digitalocean_deploy.yml
+++ b/.github/workflows/digitalocean_deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success'}}
-    runs-on: beapengine
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Updated runs-on from beapengine to ubuntu-22.04 since there isn't any self-hosted runner "beapengine" specified in the repo.
